### PR TITLE
Added support for libssl.so.10

### DIFF
--- a/lib/eth/open_ssl.rb
+++ b/lib/eth/open_ssl.rb
@@ -8,7 +8,7 @@ module Eth
     if FFI::Platform.windows?
       ffi_lib 'libeay32', 'ssleay32'
     else
-      ffi_lib ['libssl.so.1.0.0', 'ssl']
+      ffi_lib ['libssl.so.1.0.0', 'libssl.so.10', 'ssl']
     end
 
     NID_secp256k1 = 714

--- a/lib/eth/version.rb
+++ b/lib/eth/version.rb
@@ -1,3 +1,3 @@
 module Eth
-  VERSION = "0.4.4"
+  VERSION = "0.4.5"
 end


### PR DESCRIPTION
Using eth gem on CentOS without the devel package installed, it won't find the libssl.so.1.0.0 library since it's using libssl.so.10.