### PR TITLE
Fixed so that chain IDs larger than 120 are supported

### DIFF
--- a/lib/eth.rb
+++ b/lib/eth.rb
@@ -25,20 +25,12 @@ module Eth
       27
     end
 
-    def chain_id
-      configuration.chain_id
+    def default_chain_id
+      configuration.default_chain_id
     end
 
     def v_base
-      if chain_id
-        (chain_id * 2) + 35
-      else
-        replayable_chain_id
-      end
-    end
-
-    def prevent_replays?
-      !chain_id.nil?
+      replayable_chain_id
     end
 
     def replayable_v?(v)
@@ -49,7 +41,13 @@ module Eth
       !!configuration.tx_data_hex
     end
 
+    def chain_id_from_signature(signature)
+      return nil if Eth.replayable_v?(signature[:v])
 
+      cid = (signature[:v] - 35) / 2
+      (cid < 1) ? nil : cid
+    end
+    
     private
 
     def configuration
@@ -58,9 +56,10 @@ module Eth
   end
 
   class Configuration
-    attr_accessor :chain_id, :tx_data_hex
+    attr_accessor :default_chain_id, :tx_data_hex
 
     def initialize
+      self.default_chain_id = nil
       self.tx_data_hex = true
     end
   end

--- a/lib/eth/tx.rb
+++ b/lib/eth/tx.rb
@@ -44,7 +44,7 @@ module Eth
 
     def unsigned_encoded
       us = unsigned
-      RLP.encode(us, sedes: us.send(:sedes))
+      RLP.encode(us, sedes: us.sedes)
     end
 
     def signing_data
@@ -181,6 +181,8 @@ module Eth
       Tx.new to_h.merge(v: (self.chain_id) ? self.chain_id : 0, r: 0, s: 0)
     end
 
+    protected
+    
     def sedes
       if self.prevent_replays? && !(Eth.replayable_v? v)
         self.class

--- a/spec/eth/eip155_spec.rb
+++ b/spec/eth/eip155_spec.rb
@@ -1,7 +1,7 @@
 describe 'EIP 155 and replay protection' do
   let(:key) { Eth::Key.new priv: '4646464646464646464646464646464646464646464646464646464646464646' }
 
-  context "EIP155 example", chain_id: 1 do
+  context "EIP155 example" do
     #via https://github.com/ethereum/EIPs/issues/155#issue-183002027
 
     let(:hex) { '0xf86c098504a817c800825208943535353535353535353535353535353535353535880de0b6b3a76400008025a006f3c7fb391722beb8ae599a899fe6fd6f6eae4b0f3df4bbc54bc3c673aa92cda0423bb70e7f851514a73a14cee940ec0acab1bab6fb274fa7b922adbdcbf08611' }
@@ -10,14 +10,16 @@ describe 'EIP 155 and replay protection' do
     let(:signing_data) { tx.unsigned_encoded }
 
     it "decodes the transaction and recognizes the signer" do
-      v_val, r_val, s_val = Eth::Utils.v_r_s_for tx.signature
+      sig = tx.signature
 
-      expect(v_val).to eq 37
-      expect(r_val).to eq 3144601148722688608716531623347812328676993065715946531989621665587339629261
-      expect(s_val).to eq 29958155393767630265145914935642492209353907522463775796041782419660953650705
+      expect(tx.chain_id).to eq 1
+      
+      expect(sig[:v]).to eq 37
+      expect(sig[:r]).to eq 3144601148722688608716531623347812328676993065715946531989621665587339629261
+      expect(sig[:s]).to eq 29958155393767630265145914935642492209353907522463775796041782419660953650705
 
       expect(bin_to_hex signing_data).to eq(expected_signing_data)
-      expect(key.verify_signature signing_data, tx.signature).to be true
+      expect(key.verify_signature signing_data, tx.ecdsa_signature).to be true
       expect(key.address).to eq(tx.from)
     end
   end
@@ -25,6 +27,7 @@ describe 'EIP 155 and replay protection' do
   context "pre-EIP155 fork" do
     let(:hex) do
       Eth::Tx.new({
+        chain_id: nil,
         nonce: 9,
         gas_price: (20 * 10**9),
         gas_limit: 21000,
@@ -37,57 +40,13 @@ describe 'EIP 155 and replay protection' do
     let(:tx) { Eth::Tx.decode hex }
 
     it "decodes the transaction and recognizes the signer" do
-      v_val, r_val, s_val = Eth::Utils.v_r_s_for tx.signature
+      sig = tx.signature
       signing_data = tx.unsigned_encoded
 
-      expect([Eth.v_base, (Eth.v_base + 1)]).to include v_val
+      expect([Eth.v_base, (Eth.v_base + 1)]).to include sig[:v]
 
       expect(bin_to_hex signing_data).to eq(expected_signing_data)
-      expect(key.verify_signature signing_data, tx.signature).to be true
-    end
-  end
-
-  context "verifying a post-EIP155 signature with pre-EIP155 configuration" do
-    let(:tx) do
-      Eth::Tx.new({
-        nonce: 9,
-        gas_price: (20 * 10**9),
-        gas_limit: 21000,
-        to: '0x3535353535353535353535353535353535353535',
-        value: (10**18),
-        data: '',
-      })
-    end
-
-    it "cannot verify the signature" do
-      configure_chain_id 3
-      signature = tx.sign(key).signature
-      configure_defaults
-
-      expect(key.verify_signature tx.unsigned_encoded, signature).to be false
-    end
-  end
-
-  context "verifying a pre-EIP155 signature with a post-EIP155 configuration" do
-    let(:pre_tx) do
-      Eth::Tx.new({
-        nonce: 9,
-        gas_price: (20 * 10**9),
-        gas_limit: 21000,
-        to: '0x3535353535353535353535353535353535353535',
-        value: (10**18),
-        data: '',
-      })
-    end
-
-    it "can verify the signature" do
-      configure_defaults
-      pre_tx.sign(key)
-      pre_tx_hex = pre_tx.hex
-      configure_chain_id 3
-      post_tx = Eth::Tx.decode pre_tx_hex
-
-      expect(key.verify_signature post_tx.unsigned_encoded, post_tx.signature).to be true
+      expect(key.verify_signature signing_data, tx.ecdsa_signature).to be true
     end
   end
 end

--- a/spec/eth/eth_spec.rb
+++ b/spec/eth/eth_spec.rb
@@ -1,30 +1,11 @@
 describe Eth do
 
   describe ".configure" do
-    it "defaults to nil" do
-      expect(Eth.chain_id).to be_nil
-    end
-
-    it "allows you to configure the chain ID" do
-      expect {
-        Eth.configure { |config| config.chain_id = 42 }
-      }.to change {
-        Eth.chain_id
-      }.from(nil).to(42)
-    end
   end
 
   describe "#v_base" do
     it "is set to 27 by default" do
       expect(Eth.v_base).to eq(27)
-    end
-
-    it "calculates it off of the chain ID" do
-      expect {
-        Eth.configure { |config| config.chain_id = 42 }
-      }.to change {
-        Eth.v_base
-      }.from(27).to(119)
     end
   end
 
@@ -41,22 +22,19 @@ describe Eth do
     end
   end
 
-  describe "#prevent_replays?" do
-    subject { Eth.prevent_replays? }
-
-    context "when configured to the defaults" do
-      before { configure_defaults }
-      it { is_expected.to be false }
-    end
-
-    context "when configured to a new chain" do
-      before { configure_chain_id 42 }
-      it { is_expected.to be true }
-    end
-
-    context "when configured to the replayable chain" do
-      before { configure_chain_id 13 }
-      it { is_expected.to be true }
+  describe "#chain_id_from_signature" do
+    it "converts v to the correct chain ID" do
+      expect(Eth.chain_id_from_signature({ v: 27, r: 0, s: 0 })).to be_nil
+      expect(Eth.chain_id_from_signature({ v: 28, r: 0, s: 0 })).to be_nil
+      expect(Eth.chain_id_from_signature({ v: 29, r: 0, s: 0 })).to be_nil
+      expect(Eth.chain_id_from_signature({ v: 30, r: 0, s: 0 })).to be_nil
+      expect(Eth.chain_id_from_signature({ v: 36, r: 0, s: 0 })).to be_nil
+      expect(Eth.chain_id_from_signature({ v: 37, r: 0, s: 0 })).to eq(1)
+      expect(Eth.chain_id_from_signature({ v: 38, r: 0, s: 0 })).to eq(1)
+      expect(Eth.chain_id_from_signature({ v: 119, r: 0, s: 0 })).to eq(42)
+      expect(Eth.chain_id_from_signature({ v: 120, r: 0, s: 0 })).to eq(42)
+      expect(Eth.chain_id_from_signature({ v: 867, r: 0, s: 0 })).to eq(416)
+      expect(Eth.chain_id_from_signature({ v: 868, r: 0, s: 0 })).to eq(416)
     end
   end
 end

--- a/spec/eth/key_spec.rb
+++ b/spec/eth/key_spec.rb
@@ -31,21 +31,6 @@ describe Eth::Key, type: :model do
         expect(s_value).to be < (Eth::Secp256k1::N/2)
       end
     end
-
-    context "when the network ID has been changed", chain_id: 42 do
-      it "signs a message so that the public key is recoverable" do
-        v_base = Eth.v_base
-        expect(v_base).to eq(119)
-
-        10.times do
-          signature = key.sign message
-          expect(key.verify_signature message, signature).to be_truthy
-          v_val, r_val, s_val = Eth::Utils.v_r_s_for(signature)
-          expect(s_val).to be < (Eth::Secp256k1::N/2)
-          expect([v_base, v_base + 1]).to include(v_val)
-        end
-      end
-    end
   end
 
   describe "#personal_sign" do
@@ -94,28 +79,6 @@ describe Eth::Key, type: :model do
 
       it "signs a message so that the public key is recoverable" do
         expect(key.verify_signature message, signature).to be_falsy
-      end
-    end
-
-    context "when the network ID has been changed", chain_id: 42 do
-      let(:new_signature) { hex_to_bin '778bb9158ca2b1d64f97355839efef7564e8a960f2d8429c3001f3ecf6404fa0e83659a62ceb7f137d495d3f71dac967b6aab84ad3c06e50990df25c3caf202854' }
-
-      it "can verify signatures from the new network" do
-        v = Eth::Utils.v_r_s_for(new_signature).first
-        expect([119, 120]).to include v
-        expect(key.verify_signature message, new_signature).to be_truthy
-      end
-
-      it "can verify replayable signatures" do
-        v = Eth::Utils.v_r_s_for(signature).first
-        expect([27, 28]).to include v
-        expect(key.verify_signature message, signature).to be_truthy
-      end
-
-      it "cannot verify signatures from other non replayable networks" do
-        configure_chain_id 3
-
-        expect(key.verify_signature message, new_signature).to be_falsey
       end
     end
   end

--- a/spec/eth/tx_spec.rb
+++ b/spec/eth/tx_spec.rb
@@ -19,10 +19,53 @@ describe Eth::Tx, type: :model do
       data: data,
       v: v,
       r: r,
-      s: s,
+      s: s
     })
   end
-
+  let(:tx_fields_42) do
+    {
+      chain_id: 42,
+      nonce: nonce,
+      gas_price: gas_price,
+      gas_limit: gas_limit,
+      to: recipient,
+      value: value,
+      data: data,
+      v: v,
+      r: r,
+      s: s
+    }
+  end
+  let(:tx_fields_416) do
+    {
+      chain_id: 416,
+      nonce: nonce,
+      gas_price: gas_price,
+      gas_limit: gas_limit,
+      to: recipient,
+      value: value,
+      data: data,
+      v: v,
+      r: r,
+      s: s
+    }
+  end
+  let(:tx_fields_encoded_416) do
+    {
+      data: '0xc950f8f0000000000000000000000000762a441605c438742754bb357dd241c8326c25e0000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000028',
+      to: '0x69351bffb36f3d1a6fa4374da03562a1935e7047',
+      gas_price: 0x3b9aca00,
+      value: 0x0,
+      nonce: 99,
+      chain_id: 416,
+      from: '0x22441c383a1e27acbf99663f1861e4936ac86049',
+      gas_limit: 71115
+    }
+  end
+  let(:tx_encoded_416) do
+    '0xf8cb63843b9aca00830115cb9469351bffb36f3d1a6fa4374da03562a1935e704780b864c950f8f0000000000000000000000000762a441605c438742754bb357dd241c8326c25e0000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000028820364a03944cee478f84e7186b726858a03b7212281dfd0045df6c22bfb101042a8115ca07676eec5290861869cbd4e029cb8aecb17571dfd2de2499809e462595a956e39'
+  end
+  
   describe "#initialize" do
     it "sets the arguments in the order of serializable fields" do
       expect(tx.nonce).to eq(nonce)
@@ -60,13 +103,33 @@ describe Eth::Tx, type: :model do
         expect(tx.data).to eq(data)
       end
     end
+
+    context "when chain_id is not in the parameters" do
+      it "uses the default chain ID" do
+        cid = Eth.default_chain_id
+        configure_default_chain_id 42
+        tx = Eth::Tx.new({
+                           nonce: nonce,
+                           gas_price: gas_price,
+                           gas_limit: gas_limit,
+                           to: recipient,
+                           value: value,
+                           data: data,
+                           v: v,
+                           r: r,
+                           s: s
+                         })
+        configure_default_chain_id cid
+        expect(tx.chain_id).to eq 42
+      end
+    end
   end
 
   describe ".decode" do
     let(:key) { Eth::Key.new }
     let(:tx1) { tx.sign key }
 
-    it "returns an instance that matches the original enocded one" do
+    it "returns an instance that matches the original encoded one" do
       tx2 = Eth::Tx.decode tx1.encoded
       expect(tx2).to eq(tx1)
     end
@@ -74,6 +137,26 @@ describe Eth::Tx, type: :model do
     it "also accepts hex" do
       tx2 = Eth::Tx.decode(tx1.hex)
       expect(tx2).to eq(tx1)
+    end
+
+    it "decodes Web3.js generated data correctly" do
+      tx_416 = Eth::Tx.new tx_fields_encoded_416
+      tx2 = Eth::Tx.decode tx_encoded_416
+      fields = tx_fields_encoded_416.keys
+      tx2_fields = tx2.to_h.select { |k, v| tx_fields_encoded_416.include?(k) }
+      tx_416_fields = tx_416.to_h.select { |k, v| tx_fields_encoded_416.include?(k) }
+      expect(tx2_fields).to eq(tx_416_fields)
+    end
+
+    it "initializes chain_id correctly" do
+      tx_416 = Eth::Tx.new tx_fields_encoded_416
+      expect(tx_416.chain_id).to eq 416
+    end
+
+    it "ignores the default chain ID" do
+      configure_default_chain_id 42
+      tx_416 = Eth::Tx.new tx_fields_encoded_416
+      expect(tx_416.chain_id).to eq 416
     end
   end
 
@@ -83,10 +166,64 @@ describe Eth::Tx, type: :model do
     let(:s) { nil }
     let(:key) { Eth::Key.new }
 
-    it "creates a recoverable signature for the transaction" do
-      tx.sign key
-      verified = key.verify_signature tx.unsigned_encoded, tx.signature
-      expect(verified).to be_truthy
+    context "creates a recoverable signature for the transaction" do
+      it "with undefined chain ID" do
+        tx.sign key
+        verified = key.verify_signature tx.unsigned_encoded, tx.ecdsa_signature
+        expect(verified).to be_truthy
+      end
+
+      it "with small chain ID" do
+        tx_42 = Eth::Tx.new(tx_fields_42)
+        expect(tx_42.chain_id).to equal(42)
+        tx_42.sign key
+        verified = key.verify_signature tx_42.unsigned_encoded, tx_42.ecdsa_signature
+        expect(verified).to be_truthy
+      end
+
+      it "with large chain ID" do
+        tx_416 = Eth::Tx.new(tx_fields_416)
+        expect(tx_416.chain_id).to equal(416)
+        tx_416.sign key
+        verified = key.verify_signature tx_416.unsigned_encoded, tx_416.ecdsa_signature
+        expect(verified).to be_truthy
+      end
+
+      it "with nil chain ID" do
+        nil_fields = tx_fields_416
+        nil_fields[:chain_id] = nil
+        tx_nil = Eth::Tx.new(nil_fields)
+        expect(tx_nil.chain_id).to be_nil
+        tx_nil.sign key
+        verified = key.verify_signature tx_nil.unsigned_encoded, tx_nil.ecdsa_signature
+        expect(verified).to be_truthy
+      end
+
+      it "after chain ID is modified" do
+        tx_42 = Eth::Tx.new(tx_fields_42)
+        expect(tx_42.chain_id).to equal(42)
+        tx_42.sign key
+        verified = key.verify_signature tx_42.unsigned_encoded, tx_42.ecdsa_signature
+        expect(verified).to be_truthy
+
+        tx_42.chain_id = 616
+        tx_42.sign key
+        verified = key.verify_signature tx_42.unsigned_encoded, tx_42.ecdsa_signature
+        expect(verified).to be_truthy
+      end
+    end
+
+    context "generates the same signer for the transaction" do
+      it "after chain ID is modified" do
+        tx_42 = Eth::Tx.new(tx_fields_42)
+        expect(tx_42.chain_id).to equal(42)
+        tx_42.sign key
+        expect(tx_42.from).to eq(key.address)
+        tx_42.chain_id = 616
+        expect(tx_42.from).to be_nil
+        tx_42.sign key
+        expect(tx_42.from).to eq(key.address)
+      end
     end
   end
 
@@ -166,6 +303,41 @@ describe Eth::Tx, type: :model do
 
       it { is_expected.to be_nil }
     end
+
+    context "from a decoded transaction" do
+      it "returns the correct sender" do
+        tx2 = Eth::Tx.decode tx_encoded_416
+        expect(tx2.from.upcase).to eq(tx_fields_encoded_416[:from].upcase)
+      end
+    end
+
+    context "when the chain ID is changed" do
+      let(:key) { Eth::Key.new priv: '4bdd21761a483f71054e14f5b827213567971c676928d9a1808cbfa4b7501200' }
+
+      it "returns a nil sender if the chain ID did change" do
+        tx42 = Eth::Tx.new tx_fields_42
+        tx42.sign key
+        expect(tx42.from).to eq(key.address)
+        tx42.chain_id = 616
+        expect(tx42.from).to be_nil
+      end
+
+      it "returns a nil sender if the chain ID is nulled" do
+        tx42 = Eth::Tx.new tx_fields_42
+        tx42.sign key
+        expect(tx42.from).to eq(key.address)
+        tx42.chain_id = nil
+        expect(tx42.from).to be_nil
+      end
+
+      it "returns the same sender if the chain ID did not change" do
+        tx42 = Eth::Tx.new tx_fields_42
+        tx42.sign key
+        expect(tx42.from).to eq(key.address)
+        tx42.chain_id = tx_fields_42[:chain_id]
+        expect(tx42.from).to be_nil
+      end
+    end
   end
 
   describe "#hash" do
@@ -243,6 +415,82 @@ describe Eth::Tx, type: :model do
         }.to(binary).and change {
           tx.data_hex
         }.to("0x#{hex}")
+      end
+    end
+  end
+
+  describe "#chain_id" do
+    context "when transaction was signed explicitly" do
+      let(:key) { Eth::Key.new }
+      let(:tx42) { Eth::Tx.new tx_fields_42 }
+
+      it "nulls the signature on a chain ID change" do
+        tx42.sign key
+
+        expect(tx42.chain_id).to equal(42)
+        expect(tx42.signature).to be_a(Hash)
+        expect(tx42.signature).to include(:v, :r, :s)
+        tx42.chain_id = 416
+        expect(tx42.chain_id).to equal(416)
+        expect(tx42.signature).to be_nil
+      end
+
+      it "nulls the signature when chain ID is nulled" do
+        tx42.sign key
+
+        expect(tx42.chain_id).to equal(42)
+        expect(tx42.signature).to be_a(Hash)
+        expect(tx42.signature).to include(:v, :r, :s)
+        tx42.chain_id = nil
+        expect(tx42.chain_id).to be_nil
+        expect(tx42.signature).to be_nil
+      end
+
+      it "keeps the signature if chain ID does not change" do
+        tx42.sign key
+
+        expect(tx42.chain_id).to equal(42)
+        expect(tx42.signature).to be_a(Hash)
+        expect(tx42.signature).to include(:v, :r, :s)
+        osig = {}.merge(tx42.signature)
+        tx42.chain_id = 42
+        expect(tx42.chain_id).to equal(42)
+        expect(tx42.signature).to eq(osig)
+      end
+    end
+
+    context "when transaction was decoded" do
+      let(:tx416) { Eth::Tx.decode tx_encoded_416 }
+      
+      it "nulls the signature on a chain ID change" do
+        tx416 = Eth::Tx.decode tx_encoded_416
+        expect(tx416.chain_id).to equal(416)
+        expect(tx416.signature).to be_a(Hash)
+        expect(tx416.signature).to include(:v, :r, :s)
+        tx416.chain_id = 42
+        expect(tx416.chain_id).to equal(42)
+        expect(tx416.signature).to be_nil
+      end
+
+      it "nulls the signature when chain ID is nulled" do
+        tx416 = Eth::Tx.decode tx_encoded_416
+        expect(tx416.chain_id).to equal(416)
+        expect(tx416.signature).to be_a(Hash)
+        expect(tx416.signature).to include(:v, :r, :s)
+        tx416.chain_id = nil
+        expect(tx416.chain_id).to be_nil
+        expect(tx416.signature).to be_nil
+      end
+
+      it "keeps the signature if chain ID does not change" do
+        tx416 = Eth::Tx.decode tx_encoded_416
+        expect(tx416.chain_id).to equal(416)
+        expect(tx416.signature).to be_a(Hash)
+        expect(tx416.signature).to include(:v, :r, :s)
+        osig = {}.merge(tx416.signature)
+        tx416.chain_id = 416
+        expect(tx416.chain_id).to equal(416)
+        expect(tx416.signature).to eq(osig)
       end
     end
   end

--- a/spec/ethereum_tests_spec.rb
+++ b/spec/ethereum_tests_spec.rb
@@ -1,7 +1,7 @@
 require 'json'
 
 describe "Ethereum common tests" do
-  before { configure_chain_id 1 }
+  before { configure_default_chain_id 1 }
 
   it "passes all the transaction tests" do
     [

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,14 +18,14 @@ module Helpers
 
   def configure_defaults
     Eth.configure do |config|
-      config.chain_id = nil
+      config.default_chain_id = nil
       config.tx_data_hex = true
     end
   end
 
-  def configure_chain_id(id)
+  def configure_default_chain_id(id)
     Eth.configure do |config|
-      config.chain_id = id
+      config.default_chain_id = id
     end
   end
 


### PR DESCRIPTION
- move the chain_id into the transaction object and out of the global configuration
- pass ECDSA keys (where v is 27 or 28) to the sign and recover functions, to avoid the overflow bug that necessitated these changes
- upgraded tests, including removing some that are no longer relevant

See related issue at https://github.com/se3000/ruby-eth/issues/31