### PR TITLE
Update version of scrypt to support macOS Mojave

### DIFF
--- a/eth.gemspec
+++ b/eth.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'ffi', '~> 1.0'
   spec.add_dependency 'money-tree', '~> 0.10.0'
   spec.add_dependency 'rlp', '~> 0.7.3'
-  spec.add_dependency 'scrypt', '~> 3.0.5'
+  spec.add_dependency 'scrypt', '~> 3.0.6'
 
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'pry', '~> 0.1'


### PR DESCRIPTION
More detail: https://github.com/pbhogan/scrypt/releases/tag/3.0.6