### PR TITLE
Allow for version 0 which is a valid version usually from Ledger hard…

### DIFF
--- a/lib/eth/open_ssl.rb
+++ b/lib/eth/open_ssl.rb
@@ -208,7 +208,15 @@ module Eth
         return false if signature.bytesize != 65
 
         version = signature.unpack('C')[0]
+
+        # Version of signature should be 27 or 28, but 0 and 1 are also possible versions
+        # which can show up in Ledger hardwallet signings
+        if version < 27
+          version += 27
+        end
+
         v_base = Eth.replayable_v?(version) ? Eth.replayable_chain_id : Eth.v_base
+
         return false if version < v_base
 
         recover_public_key_from_signature(hash, signature, (version - v_base), false)

--- a/spec/eth/key_spec.rb
+++ b/spec/eth/key_spec.rb
@@ -61,9 +61,7 @@ describe Eth::Key, type: :model do
       let(:public_hex) { "04e51ff5abc511f2fda0f893c10054123e92527b5e69e24cca538e74edbd604508259e1b265b54628bc8024fb791e459f67adb770b20962eb38fabe8b86f2aebaa" }
 
       it "it can recover a public key from a signature generated with ledger/metamask" do
-        10.times do
-          expect(Eth::Key.personal_recover message, signature).to eq(public_hex)
-        end
+        expect(Eth::Key.personal_recover message, signature).to eq(public_hex)
       end
     end
   end

--- a/spec/eth/key_spec.rb
+++ b/spec/eth/key_spec.rb
@@ -54,6 +54,18 @@ describe Eth::Key, type: :model do
         expect(Eth::Key.personal_recover message, signature).to eq(public_hex)
       end
     end
+
+    context 'when signing with ledger that uses signature with v = 0' do
+      let(:message) { "test" }
+      let(:signature) { "0x5c433983b23738940ce256c59d5bc6a3d5fd12c5bc9bdbf0ffdffb7be1a09d1815ca1db167c61a10945837f3fb4821086d6656b4fa6ede9c4d1aeaf07e2b0adf01" }
+      let(:public_hex) { "04e51ff5abc511f2fda0f893c10054123e92527b5e69e24cca538e74edbd604508259e1b265b54628bc8024fb791e459f67adb770b20962eb38fabe8b86f2aebaa" }
+
+      it "it can recover a public key from a signature generated with ledger/metamask" do
+        10.times do
+          expect(Eth::Key.personal_recover message, signature).to eq(public_hex)
+        end
+      end
+    end
   end
 
   describe "#verify_signature" do


### PR DESCRIPTION
…wallet signatures

Source: https://yos.io/2018/11/16/ethereum-signatures/