### PR TITLE
gems: replace digest-sha3-patched with keccak

### DIFF
--- a/eth.gemspec
+++ b/eth.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'digest-sha3-patched-ruby-3', '~> 1.1'
+  spec.add_dependency 'keccak', '~> 1.2'
   spec.add_dependency 'ffi', '~> 1.0'
   spec.add_dependency 'money-tree', '~> 0.10.0'
   spec.add_dependency 'rlp', '~> 0.7.3'

--- a/eth.gemspec
+++ b/eth.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'digest-sha3-patched', '~> 1.1'
+  spec.add_dependency 'digest-sha3-patched-ruby-3', '~> 1.1'
   spec.add_dependency 'ffi', '~> 1.0'
   spec.add_dependency 'money-tree', '~> 0.10.0'
   spec.add_dependency 'rlp', '~> 0.7.3'


### PR DESCRIPTION
This is the most minimal change required to get `eth` working on Ruby 3.0.0. Ref #57 

It would be really appreciated if you could bundle a release with this @se3000 