### PR TITLE
Remove 'digest/sha3' dependency

### DIFF
--- a/eth.gemspec
+++ b/eth.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'digest-sha3-patched', '~> 1.1'
+  spec.add_dependency 'digest', '~> 3.0.0'
   spec.add_dependency 'ffi', '~> 1.0'
   spec.add_dependency 'money-tree', '~> 0.10.0'
   spec.add_dependency 'rlp', '~> 0.7.3'

--- a/lib/eth.rb
+++ b/lib/eth.rb
@@ -1,4 +1,4 @@
-require 'digest/sha3'
+require 'digest'
 require 'ffi'
 require 'money-tree'
 require 'rlp'


### PR DESCRIPTION
Digest now supports SHA3;
'digest/sha3' gem is unsupported fot rails 3