### PR TITLE
gems: bump keccak to 1.3.0

### DIFF
--- a/eth.gemspec
+++ b/eth.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.test_files    = spec.files.grep %r{^(test|spec|features)/}
 
-  spec.add_dependency 'keccak', '~> 1.2'
+  spec.add_dependency 'keccak', '~> 1.3'
   spec.add_dependency 'ffi', '~> 1.15'
   spec.add_dependency 'money-tree', '~> 0.10'
   spec.add_dependency 'rlp', '~> 0.7'

--- a/lib/eth.rb
+++ b/lib/eth.rb
@@ -1,4 +1,4 @@
-require 'digest/sha3'
+require 'digest/keccak'
 require 'ffi'
 require 'money-tree'
 require 'rlp'

--- a/lib/eth/utils.rb
+++ b/lib/eth/utils.rb
@@ -1,6 +1,5 @@
 module Eth
   module Utils
-
     extend self
 
     def normalize_address(address)
@@ -66,11 +65,11 @@ module Eth
     end
 
     def keccak256(x)
-      Digest::SHA3.new(256).digest(x)
+      Digest::Keccak.new(256).digest(x)
     end
 
     def keccak512(x)
-      Digest::SHA3.new(512).digest(x)
+      Digest::Keccak.new(512).digest(x)
     end
 
     def keccak256_rlp(x)


### PR DESCRIPTION
bump `keccak` to 1.3.0; rename `::SHA3` to `::Keccak`
* ref https://github.com/q9f/keccak.rb/pull/16